### PR TITLE
Change templates

### DIFF
--- a/ebsco/ebsco.module
+++ b/ebsco/ebsco.module
@@ -68,9 +68,29 @@ function ebsco_theme() {
     ),
     'ebsco_results' => array(
       'template' => 'templates/ebsco-results',
+      'variables' => array(
+        'lookfor' => NULL,
+        'pager' => NULL,
+        'record_count' => NULL,
+        'record_end' => NULL,
+        'record_start' => NULL,
+        'records' => NULL,
+        'search_time' => NULL,
+        'search_view' => NULL,
+        'sort_form' => NULL,
+      ),
     ),
     'ebsco_side_facets' => array(
       'template' => 'templates/ebsco-side-facets',
+      'variables' => array(
+        'record_count' => NULL,
+        'expanders' => NULL,
+        'limiters' => NULL,
+        'facets' => NULL,
+        'filters' => NULL,
+        'search_params' => NULL,
+        'link_search_params' => NULL,
+      ),
     ),
     'ebsco_basic_search' => array(
       'template' => 'templates/ebsco-basic-search',
@@ -395,10 +415,43 @@ function ebsco_basic_search_block() {
 }
 
 /**
- * EBSCO side facets block callback.
+ * Init the EBSCODocument search.
  */
+function ebsco_init_search_document($params = NULL) {
+  // If there are input params also ensure that we add the
+  // request params where we receive the page, sort, etc.
+  if ($params) {
+    $params += $_REQUEST;
+  }
+
+  $_ebsco_document = &drupal_static(__FUNCTION__, array());
+  if (empty($_ebsco_document)) {
+    $_ebsco_document = new EBSCODocument($params);
+    $_ebsco_document->info();
+    $_ebsco_document->search();
+  }
+  return $_ebsco_document;
+}
+
 function ebsco_side_facets_block() {
-  return theme('ebsco_side_facets');
+  // only build the facets when viewed page is ebsco search
+  if (request_path() != 'search/ebsco') {
+    return;
+  }
+  $_ebsco_document = ebsco_init_search_document();
+  $variables['record_count'] = $_ebsco_document->record_count();
+  //$variables['expanders'] = $_ebsco_document->expanders();
+  //$variables['limiters'] = $_ebsco_document->limiters();
+  $variables['facets'] = $_ebsco_document->facets();
+
+  // Applied facets, limiters or expanders
+  $variables['filters'] = $_ebsco_document->filters();
+
+  // Hidden parameters.
+  $variables['search_params'] = $_ebsco_document->search_params();
+  $variables['link_search_params'] = $_ebsco_document->link_search_params();
+
+  return theme('ebsco_side_facets', $variables);
 }
 
 /******************************************************
@@ -877,23 +930,14 @@ function ebsco_advanced_search_form_submit($form, &$form_state) {
 }
 
 /**
- * Process variables for ebsco-results.tpl.php.
- *
- * @see ebsco-results.tpl.php
+ * Get the search results.
  */
-function template_preprocess_ebsco_results(&$variables) {
-  global $_ebsco_document;
+function ebsco_get_search_results() {
+  $_ebsco_document = ebsco_init_search_document();
   $params = $_REQUEST;
-
-  $_SESSION['EBSCO']['redirect'] = drupal_get_destination();
-  if (empty($_ebsco_document)) {
-    $_ebsco_document = new EBSCODocument();
-  }
 
   $title = !empty($params['lookfor']) ? ' - ' . $params['lookfor'] : '';
   drupal_set_title('Search results' . $title);
-
-  $_ebsco_document->search();
 
   $variables['records'] = $_ebsco_document->records();
   $variables['record_start'] = $_ebsco_document->record_start();
@@ -904,10 +948,11 @@ function template_preprocess_ebsco_results(&$variables) {
   $variables['relatedContent'] = $_ebsco_document->relatedContent();
   $variables['autoSuggestTerms'] = $_ebsco_document->autoSuggestTerms();
   $variables['lookfor'] = '';
+
   if (isset($params['lookfor'])) {
     $variables['lookfor'] = $params['lookfor'];
   }
-  elseif (isset($params['group'])) {
+  else if (isset($params['group'])) {
     $types = EBSCODocument::basic_search_type_options();
     foreach ($params['group'] as $key => $group) {
       if (!empty($group['lookfor'])) {
@@ -918,11 +963,14 @@ function template_preprocess_ebsco_results(&$variables) {
   }
   $variables['pager'] = $_ebsco_document->pager();
 
-  $v1 = drupal_get_form('ebsco_sort_form');
-  $variables['sort_form'] = drupal_render($v1);
+  $sort_form = drupal_get_form('ebsco_sort_form');
+  $variables['sort_form'] = drupal_render($sort_form);
 
   // Save data needed by scroller in Detailed view page
-  // $_ebsco_document->search_write();
+  //$_ebsco_document->search_write();
+
+  // theme results
+  return theme('ebsco_results', $variables);
 }
 
 /**
@@ -996,31 +1044,6 @@ function template_preprocess_ebsco_result(&$variables) {
   $variables['last_search'] = $lastSearch;
 
   drupal_set_title($record->title);
-}
-
-/**
- * Process variables for ebsco-side-facets.tpl.php.
- *
- * @see ebsco-side-facets.tpl.php
- */
-function template_preprocess_ebsco_side_facets(&$variables) {
-  global $_ebsco_document;
-
-  if (empty($_ebsco_document)) {
-    $_ebsco_document = new EBSCODocument();
-  }
-  $_ebsco_document->info();
-
-  $variables['record_count'] = $_ebsco_document->record_count();
-  $variables['expanders'] = $_ebsco_document->expanders();
-  $variables['limiters'] = $_ebsco_document->limiters();
-  $variables['facets'] = $_ebsco_document->facets();
-  // Applied facets, limiters or expanders.
-  $variables['filters'] = $_ebsco_document->filters();
-  // Hidden parameters.
-  $variables['search_params'] = $_ebsco_document->search_params();
-  // Hidden parameters.
-  $variables['link_search_params'] = $_ebsco_document->link_search_params();
 }
 
 /******************************************

--- a/ebsco/ebsco.module
+++ b/ebsco/ebsco.module
@@ -942,7 +942,7 @@ function ebsco_get_search_results() {
   $variables['records'] = $_ebsco_document->records();
   $variables['record_start'] = $_ebsco_document->record_start();
   $variables['record_end'] = $_ebsco_document->record_end();
-  $variables['record_count'] = $_ebsco_document->record_count();
+  $variables['record_count'] = ebsco_result_format($_ebsco_document->record_count());
   $variables['search_view'] = $_ebsco_document->search_view();
   $variables['search_time'] = $_ebsco_document->search_time();
   $variables['relatedContent'] = $_ebsco_document->relatedContent();
@@ -1087,4 +1087,16 @@ function auto_link($string) {
     $string
   );
   return $linkedString;
+}
+
+function ebsco_result_format($num) {
+  $x = round($num);
+  $x_number_format = number_format($x);
+  $x_array = explode(',', $x_number_format);
+  $x_parts = array('K', 'M', 'B', 'T');
+  $x_count_parts = count($x_array) - 1;
+  $x_display = $x_array[0] . ((int) $x_array[1][0] !== 0 ? '.' . $x_array[1][0] : '');
+  $x_display .= $x_parts[$x_count_parts - 1];
+
+  return $x_display;
 }

--- a/ebsco/templates/ebsco-results.tpl.php
+++ b/ebsco/templates/ebsco-results.tpl.php
@@ -42,7 +42,7 @@
     }
 
     if ($search_time){
-      echo "," . t('query time') . ":" . check_plain(round($search_time, 2)) . " s";
+      echo ", " . t('query time') . ": " . check_plain(round($search_time, 2)) . " s";
     }
 
     print $sort_form;

--- a/ebsco/templates/ebsco-results.tpl.php
+++ b/ebsco/templates/ebsco-results.tpl.php
@@ -46,7 +46,15 @@
     }
 
     print $sort_form;
-    print $pager;
+
+    if (!$hide_custom_area) {
+        print $custom_area;
+    }
+
+    if (!$hide_top_pager) {
+      print $pager;
+    }
+
 
     if (!user_is_logged_in()) {
       $link = '<a href="' . url('user') . '">' . t('Login') . '</a>';
@@ -231,7 +239,7 @@
   <?php foreach ($records as $record):
 
     $id = check_plain($record->record_id());
-    $recordUrl = url('ebsco/result', array('query' => array('id' => $id)));
+    $recordUrl = url($record->p_link, array('absolute' => TRUE));
     $fulltextUrl = url('ebsco/fulltext', array('query' => array('id' => $id)));
     $pdfUrl = url('ebsco/pdf', array('query' => array('id' => $id)));
 
@@ -244,7 +252,7 @@
     <div class="result floatleft">
       <div class="span-2">
       <?php
-        if ($record->small_thumb_link){
+        if ($record->small_thumb_link && !$hide_thumb_link){
           echo '
             <a href="' . $recordUrl . '" class="_record_link">
             <img src="' . $record->small_thumb_link . '" class="book-jacket" alt="' . t('Book jacket') . '"/>
@@ -290,7 +298,7 @@
           echo '<cite>' . $record->summary . '</cite><br />';
         }
 
-        if (!empty($record->subjects)){
+        if (!empty($record->subjects) && !$hide_record_subject){
           echo '<strong>' . t('Subjects') . '</strong>:<span class="quotestart">' . str_replace('<br />', ', ', $record->subjects) . '</span>';
         }
 
@@ -317,18 +325,20 @@
 
       <div class="result-line5">
         <?php
-        if ($record->full_text_availability){
-          echo '<a href="' . $fulltextUrl . '#html" class="icon html fulltext _record_link">';
-          echo t('HTML full text');
-          echo "</a>&nbsp; &nbsp;";
-        }
+        if (!$hide_availability) {
+          if ($record->full_text_availability){
+            echo '<a href="' . $fulltextUrl . '#html" class="icon html fulltext _record_link">';
+            echo t('HTML full text');
+            echo "</a>&nbsp; &nbsp;";
+          }
 
-         if ($record->pdf_availability){
-          echo ' <a href="' . $pdfUrl . '" class="icon pdf fulltext">';
-          echo t('PDF full text');
-          echo "</a>";
-         }
-         ?>
+          if ($record->pdf_availability){
+            echo ' <a href="' . $pdfUrl . '" class="icon pdf fulltext">';
+            echo t('PDF full text');
+            echo "</a>";
+          }
+        }
+       ?>
 
       </div>
       </div>
@@ -337,7 +347,10 @@
     </li>
   <?php endforeach; ?>
   </ol>
-  <?php print $pager; ?>
+    <?php if (!$hide_botton_pager): ?>
+      <?php print $pager; ?>
+    <?php endif; ?>
+
 
 <?php
   }

--- a/ebsco/templates/ebsco-results.tpl.php
+++ b/ebsco/templates/ebsco-results.tpl.php
@@ -51,9 +51,9 @@
         print $custom_area;
     }
 
-    if (!$hide_top_pager) {
-      print $pager;
-    }
+
+    print $pager;
+
 
 
     if (!user_is_logged_in()) {

--- a/ebsco/templates/ebsco-side-facets.tpl.php
+++ b/ebsco/templates/ebsco-side-facets.tpl.php
@@ -67,38 +67,39 @@
         </dl>
       <?php endif; ?>
 
-      <dl class="narrow-list navmenu">
-        <dt><?php print t('Limit Results'); ?></dt>
-        <?php foreach ($limiters as $limiter): ?>
-          <dd>
-            <?php if ($limiter['Type'] == 'multiselectvalue'): ?>
-              <label for="<?php print check_plain($limiter['Id']); ?>">
-                <?php print t($limiter['Label']); ?>
-              </label><br />
-              <select name="filter[]" multiple="multiple" id="<?php print check_plain($limiter['Id']); ?>">
-                <option value=""><?php print t('All'); ?></option>
-                <?php foreach ($limiter['Values'] as $option): ?>
-                  <option value="<?php print check_plain($option['Action']); ?>"<?php $option['selected'] ? ' selected="selected"' : ''; ?>>
-                    <?php print check_plain($option['Value']); ?>
-                  </option>
-                <?php endforeach; ?>
-              </select>
-            <?php else: ?>
-              <input type="checkbox" name="filter[]" value="<?php print check_plain(str_replace('value', 'y', $limiter['Action'])); ?>" 
-                <?php print $limiter['selected'] ? ' checked="checked"' : ''; ?> id="<?php print check_plain($limiter['Id']); ?>"
-              />
-              <label for="<?php print check_plain($limiter['Id']); ?>">
-                <?php print check_plain(t($limiter['Label'])); ?>
-              </label>
-            <?php endif; ?>
-          </dd>
-        <?php endforeach; ?>
-      </dl>
-
+      <?php if (count($limiters) > 0): ?>
+          <dl class="narrow-list navmenu">
+            <dt><?php print t('Limit Results'); ?></dt>
+            <?php foreach ($limiters as $limiter): ?>
+              <dd>
+                <?php if ($limiter['Type'] == 'multiselectvalue'): ?>
+                  <label for="<?php print check_plain($limiter['Id']); ?>">
+                    <?php print t($limiter['Label']); ?>
+                  </label><br />
+                  <select name="filter[]" multiple="multiple" id="<?php print check_plain($limiter['Id']); ?>">
+                    <option value=""><?php print t('All'); ?></option>
+                    <?php foreach ($limiter['Values'] as $option): ?>
+                      <option value="<?php print check_plain($option['Action']); ?>"<?php $option['selected'] ? ' selected="selected"' : ''; ?>>
+                        <?php print check_plain($option['Value']); ?>
+                      </option>
+                    <?php endforeach; ?>
+                  </select>
+                <?php else: ?>
+                  <input type="checkbox" name="filter[]" value="<?php print check_plain(str_replace('value', 'y', $limiter['Action'])); ?>"
+                    <?php print $limiter['selected'] ? ' checked="checked"' : ''; ?> id="<?php print check_plain($limiter['Id']); ?>"
+                  />
+                  <label for="<?php print check_plain($limiter['Id']); ?>">
+                    <?php print check_plain(t($limiter['Label'])); ?>
+                  </label>
+                <?php endif; ?>
+              </dd>
+            <?php endforeach; ?>
+          </dl>
+      <?php endif; ?>
       <dl class="narrow-list navmenu">
         <?php if ($expanders): ?>
           <dt><?php print t('Expand Results'); ?></dt>
-        <?php endif; ?>
+
 
         <?php foreach($expanders as $expander): ?>
           <dd>
@@ -114,6 +115,7 @@
         <dd class="submit">
           <input type="submit" name="submit" class="form-submit" value="<?php print t('Update'); ?>" />
         </dd>
+        <?php endif; ?>
       </dl>
 
       <?php if (!empty($facets)): ?>


### PR DESCRIPTION
This PR does the following:

- [ ] RESTORE: Restore the templates to the format they used before (need commit hash reference here) including:
  - [ ] replace curly braces around if statements with `<?php if (...) : ?>` and `<?php endif; ?>` 
  - [ ] pull out HTML tags outside of the embedded PHP where possible.
- [ ] QUICKFIX: Fix punctuation around 'query time'
- [ ] FEATURE: Allow hiding various result elements in the template via preprocess variables:  Thumb link, sidebar facet h2 title, top/bottom pager, HTML full text and PDF full text links, search limiters.
- [ ] REFACTOR: Move variable preparations out of template preprocess.
- [ ] PERFORMANCE: Leverage Drupal core's static caching functionality (drupal_static) to avoid global variables and costly re-instantiation of the EBSCODocument object.
  * current status: INCOMPLETE, seems to have been done for only one case, but there are still usages of the global variable throughout the code. This needs to be pulled out and worked on in a separate commit.
- [ ] SYNTAX: Code cleanup & pass Coder tests.


